### PR TITLE
Add generic issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,7 @@
 name: Bug Report
-description: File a bug report
-title: "[Bug]: "
-labels: ["bug", "triage"]
+description: 🐞 File a discovered bug report
+title: '[Bug]: '
+labels: ['bug', 'triage']
 projects: []
 assignees:
   - octocat
@@ -24,18 +24,15 @@ body:
       label: What happened?
       description: Also tell us, what did you expect to happen?
       placeholder: Tell us what you see!
-      value: "A bug happened!"
+      value: 'A bug happened!'
     validations:
       required: true
-  - type: dropdown
+  - type: input
     id: version
     attributes:
       label: Version
-      description: What version of our software are you running?
-      options:
-        - 1.0.2 (Default)
-        - 1.0.3 (Edge)
-      default: 0
+      description: What version of our software are you proposing the improvement for?
+      placeholder: ex. v1.0.0
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,36 @@
+name: Feature
+description: 🚀 Propose a new feature
+title: '[Feature]: '
+labels: ['feature', 'proposal']
+projects: []
+assignees:
+  - octocat
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What is your idea?
+      description: Also tell us, what is your idea?
+      placeholder: Tell us what what do you want to be added!
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://example.com)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,0 +1,44 @@
+name: Improvement
+description: ✨ File an improvement request to an existing feature
+title: '[Improvement]: '
+labels: ['improvement', 'proposal']
+projects: []
+assignees:
+  - octocat
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What is your idea?
+      description: Also tell us, what is your idea?
+      placeholder: Tell us what what do you want to be added!
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you proposing the improvement for?
+      placeholder: ex. v1.0.0
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://example.com)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true


### PR DESCRIPTION
### Description

This MR adds a few improvements to the current GitHub issue templates to add `feature` and `improvement` type templates, along with some minor cleanup for existing `bug` template.

### Checkout prerequisites

`N/A`

### Testing guidelines

`N/A`
